### PR TITLE
Update `User` and `Post` type examples

### DIFF
--- a/docs/0.x/03-Tutorials/02-Auth/02-Authentication-with-Facebook-for-React-&-Apollo.md
+++ b/docs/0.x/03-Tutorials/02-Auth/02-Authentication-with-Facebook-for-React-&-Apollo.md
@@ -246,7 +246,7 @@ In addition to the `User` that you got from the `facebook` authentication templa
 Open `./graphcool/types.graphql` and add the following definition to it:
 
 ```graphql(path="server/types.graphql")
-type Post {
+type Post @model {
   # Required system field:
   id: ID! @isUnique # read-only (managed by Graphcool)
 
@@ -282,7 +282,7 @@ type User @model {
   facebookEmail: String
   
   # custom fields
-  posts: [Post!]! @relation(name: "PostsByUser")
+  posts: [Post!]! @relation(name: "UsersPosts")
 }
 ```
 


### PR DESCRIPTION
Fixes the following errors when trying to deploy:

```
  Post
    ✖ The model `Post` is missing the @model directive. Please add it. See: https://github.com/graphcool/framework/issues/817
    ✖ A relation directive with a name must appear exactly 2 times. Relation name: 'UsersPosts'

  User
    ✖ A relation directive with a name must appear exactly 2 times. Relation name: 'PostsByUser'
```